### PR TITLE
Fix MediaSource support on iOS

### DIFF
--- a/components/Chat.tsx
+++ b/components/Chat.tsx
@@ -154,8 +154,30 @@ const Chat = () => {
         isBuffering: true
       }));
       
-      console.log("Creating new MediaSource");
       const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+
+      if (typeof window === 'undefined' || !("MediaSource" in window)) {
+        console.log("MediaSource not supported, falling back to blob playback");
+        const buffer = await response.arrayBuffer();
+        const blobUrl = URL.createObjectURL(new Blob([buffer], { type: 'audio/mpeg' }));
+
+        if (audioRef.current) {
+          audioRef.current.src = blobUrl;
+          audioRef.current.setAttribute('playsinline', 'true');
+          audioRef.current.setAttribute('webkit-playsinline', 'true');
+          try {
+            await audioRef.current.play();
+          } catch (err) {
+            console.error('Error playing fallback audio:', err);
+          }
+        }
+
+        setIsStreaming(false);
+        setAudioState(prev => ({ ...prev, isStreaming: false, isBuffering: false }));
+        return;
+      }
+
+      console.log("Creating new MediaSource");
       const newMediaSource = new MediaSource();
       console.log("Created new MediaSource, initial state:", newMediaSource.readyState);
       


### PR DESCRIPTION
## Summary
- detect absence of `MediaSource` API and fallback to blob playback
- ensure linting passes

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68497862b16c8333af2fd27729ce93b0